### PR TITLE
Merge exception policies

### DIFF
--- a/ChatMerge/scripts/chat-resolver.js
+++ b/ChatMerge/scripts/chat-resolver.js
@@ -28,7 +28,19 @@ export class ChatResolver {
                 return;
             }
         }
-        
+
+	if (messageData.type === 0) {
+            game.chtmrg_flag = true;
+            game.chtmrg_lastmessage = {};
+            return;
+        }
+
+        if (messageData.type !== game.chtmrg_lastmessage.data.type) {
+            game.chtmrg_flag = true;
+            game.chtmrg_lastmessage = {};
+            return;
+        }
+
         if(messageData.whisper != undefined) {
             if(!messageData.whisper.equals(game.chtmrg_lastmessage.data.whisper) || messageData.user != game.chtmrg_lastmessage.data.user) {
                 game.chtmrg_flag = true;


### PR DESCRIPTION
Not merge in following cases, since possibly broke messages in these cases;
- Card chat messages, such as items, spells, feats
- Messages with different type